### PR TITLE
Use getfield instead of eval for Packed type conversion

### DIFF
--- a/src/FGOSUtils.jl
+++ b/src/FGOSUtils.jl
@@ -4,11 +4,11 @@
 
 
 function convert{PT <: PackedInferenceType, T <:FunctorInferenceType}(::Type{PT}, ::T)
-  eval(parse("$(T.name.module).Packed$(T.name.name)"))
+  getfield(T.name.module, Symbol("Packed$(T.name.name)"))
 end
 function convert{T <: FunctorInferenceType, PT <: PackedInferenceType}(::Type{T}, ::PT)
   @show string(PT.name.name)[7:end]
-  eval(parse("$(PT.name.module).$(string(PT.name.name)[7:end])"))
+  getfield(PT.name.module, Symbol(string(PT.name.name)[7:end]))
 end
 
 

--- a/test/saveconvertertypes.jl
+++ b/test/saveconvertertypes.jl
@@ -9,7 +9,7 @@ module  Dependency
   abstract pabst
 
   convert{P <: pabst, T <: abst}(::Type{P}, ::T) =
-          eval(parse("$(T.name.module).Packed$(T.name.name)"))
+          getfield(T.name.module, Symbol("Packed$(T.name.name)"))
   convertsave(t) = convert(pabst, t)
 end
 
@@ -23,7 +23,7 @@ module Extend
   type PackedT1 <: pabst  end
 
   convert{P <: pabst, T <: abst}(::Type{P}, ::T) =
-        eval(parse("$(T.name.module).Packed$(T.name.name)"))
+        getfield(T.name.module, Symbol("Packed$(T.name.name)"))
 end
 
 


### PR DESCRIPTION
eliminates the need to overwrite these methods in other modules

as discussed at https://github.com/dehann/RoME.jl/commit/e564939b4db2bc02d26d5d9b21e2c338ec6815f4#commitcomment-21468647